### PR TITLE
fix constructor, ostream + test

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ int main() {
     LongNumber num2("9171AF3bc", 16); // base can be specified
     LongNumber num3(12);
     LongNumber num4("-1001010", 2);
-    LongNumber num5(std::string("345678aae88cd"), 15);
+    std::string s("345678aae88cd");
+    LongNumber num5(s, 15);
     num4 += 15;
     num3 += num1;
     num3.invertSign();

--- a/src/Implementation/LongNumber_AddSub.cpp
+++ b/src/Implementation/LongNumber_AddSub.cpp
@@ -188,9 +188,9 @@ void LongNumber::impl::sub(LongNumber const other){
 LongNumber LongNumber::operator-(LongNumber const &other) const{
     if (pimpl->sign != other.pimpl->sign) {
         LongNumber result(this->changeBase(other.getBase()));
-        //result.invertSign(); // this is because function `add` requires numbers to have same sign
+        result.invertSign(); // this is because function `add` requires numbers to have same sign
         result.pimpl->add(other);
-        //result.invertSign(); // the first sign (same of *this)
+        result.invertSign(); // the first sign (same of *this)
         return result;
     }
     // else
@@ -206,7 +206,7 @@ LongNumber LongNumber::operator-(LongNumber const &other) const{
     else {
         LongNumber aux(other);
         aux.pimpl->sub(this_withBaseChanged);
-        //aux.invertSign();
+        aux.invertSign();
         return aux;
     }
 }

--- a/src/Implementation/LongNumber_AddSub.cpp
+++ b/src/Implementation/LongNumber_AddSub.cpp
@@ -188,9 +188,9 @@ void LongNumber::impl::sub(LongNumber const other){
 LongNumber LongNumber::operator-(LongNumber const &other) const{
     if (pimpl->sign != other.pimpl->sign) {
         LongNumber result(this->changeBase(other.getBase()));
-        result.invertSign(); // this is because function `add` requires numbers to have same sign
+        //result.invertSign(); // this is because function `add` requires numbers to have same sign
         result.pimpl->add(other);
-        result.invertSign(); // the first sign (same of *this)
+        //result.invertSign(); // the first sign (same of *this)
         return result;
     }
     // else
@@ -206,7 +206,7 @@ LongNumber LongNumber::operator-(LongNumber const &other) const{
     else {
         LongNumber aux(other);
         aux.pimpl->sub(this_withBaseChanged);
-        aux.invertSign();
+        //aux.invertSign();
         return aux;
     }
 }

--- a/src/Implementation/LongNumber_Comparisons.cpp
+++ b/src/Implementation/LongNumber_Comparisons.cpp
@@ -4,8 +4,6 @@
  * @brief Compares two LongNumber objects with the same sign and base.
  * @return An enum indicating whether *this is greater than, equal to, or less than 'other'.
  * @warning This function requires both the sign and base to be the same between *this and 'other'.
- * @bug The function compares the absolute values, but if both numbers are negative, the result
- * should be inverted.
  */
 LongNumber::impl::comparison_result LongNumber::impl::comparison(LongNumber const& other) const {
     pcella aux1 = end;
@@ -107,10 +105,6 @@ bool LongNumber::equals(long long other) const{
     LongNumber aux = LongNumber(other);
     return (getBase() == aux.getBase()) && *this==aux;
 }
-/**
- * @bug un numero (valore assoluto) maggiore di un altro, se negativi, è minore, non
- * maggiore 
-*/
 bool LongNumber::operator>=(LongNumber const &other) const{
     if (this->pimpl->sign != other.pimpl->sign){
         return pimpl->sign;
@@ -151,10 +145,6 @@ bool LongNumber::operator>=(long other) const{
 bool LongNumber::operator>=(long long other) const{
     return *this >= LongNumber(other);
 }
-/**
- * @bug un numero (valore assoluto) maggiore di un altro, se negativi, è minore, non
- * maggiore 
-*/
 bool LongNumber::operator<=(LongNumber const &other) const{
     if (this->pimpl->sign != other.pimpl->sign){
         return !(pimpl->sign);
@@ -195,10 +185,6 @@ bool LongNumber::operator<=(long other) const{
 bool LongNumber::operator<=(long long other) const{
     return *this<=LongNumber(other);
 }
-/**
- * @bug un numero (valore assoluto) maggiore di un altro, se negativi, è minore, non
- * maggiore 
-*/
 bool LongNumber::operator<(LongNumber const &other) const{
     if (this->pimpl->sign != other.pimpl->sign){
         return !(pimpl->sign);
@@ -239,10 +225,6 @@ bool LongNumber::operator<(long other) const{
 bool LongNumber::operator<(long long other) const{
     return *this < LongNumber(other);
 }
-/**
- * @bug un numero (valore assoluto) maggiore di un altro, se negativi, è minore, non
- * maggiore 
-*/
 bool LongNumber::operator>(LongNumber const &other) const{
     if (this->pimpl->sign != other.pimpl->sign){
         return (pimpl->sign);

--- a/src/Implementation/LongNumber_Constructors.cpp
+++ b/src/Implementation/LongNumber_Constructors.cpp
@@ -1,16 +1,17 @@
 #include "../LongNumber_StructImpl.hpp"
+#include <iostream>
+
 
 LongNumber::LongNumber(){
-    *this = LongNumber(10, true);
+    pimpl = new impl;
 }
 LongNumber::LongNumber(int base, bool sign){
     if (base < 2 || base > 16){
-        throw new LongNumberException{"La base deve essere compresa tra 2 e 16"};
+        throw LongNumberException{"La base deve essere compresa tra 2 e 16"};
     }
     this->pimpl = new impl;
     pimpl->sign = sign;
     pimpl->base = base;
-    pimpl->start = pimpl->end = nullptr;
 }
 
 // destructor
@@ -21,22 +22,14 @@ LongNumber::~LongNumber(){
 
 // Copy Constructor
 LongNumber::LongNumber(LongNumber const &other) {
-    if (this != &other) {  // Verifica se non stai assegnando a te stesso
-        if (pimpl) delete pimpl;  // Dealloca la struttura di implementazione corrente
         pimpl = new impl;
         pimpl->sign = other.pimpl->sign;
         pimpl->base = other.pimpl->base;
-        typename impl::pcella aux = other.pimpl->start;
-        if (aux==nullptr) {
-            pimpl->start = pimpl->end = nullptr;
+        impl::pcella aux = other.pimpl->start;
+        while(aux) {
+            pimpl->push_back(aux->value);
+            aux=aux->next;
         }
-        else {
-            while(aux) {
-                pimpl->push_back(aux->value);
-                aux = aux->next;
-            }
-        }
-    }
 }
 
 // Move Constructor
@@ -48,19 +41,14 @@ LongNumber::LongNumber(LongNumber &&other) {
 // Copy Assignment Operator
 LongNumber& LongNumber::operator=(LongNumber const &other) {
     if (this != &other) {  // Verifica se non stai assegnando a te stesso
-        if (pimpl) delete pimpl;  // Dealloca la struttura di implementazione corrente
+        delete pimpl;  // Dealloca la struttura di implementazione corrente
         pimpl = new impl;
-        pimpl->sign = other.pimpl->sign;
         pimpl->base = other.pimpl->base;
-        typename impl::pcella aux = other.pimpl->start;
-        if (aux==nullptr) {
-            pimpl->start = pimpl->end = nullptr;
-        }
-        else {
-            while(aux) {
-                pimpl->push_back(aux->value);
-                aux = aux->next;
-            }
+        pimpl->sign = other.pimpl->sign;
+        impl::pcella aux = other.pimpl->start;
+        while(aux) {
+            pimpl->push_back(aux->value);
+            aux=aux->next;
         }
     }
     return *this;
@@ -78,27 +66,35 @@ LongNumber& LongNumber::operator=(LongNumber &&other) {
 
 // Wraps primitive types to LongNumber Objects
 LongNumber::LongNumber(unsigned short value){
+    pimpl = new impl;
     *this = LongNumber(static_cast<long long>(value));
 }
 LongNumber::LongNumber(unsigned int value){
+    pimpl = new impl;
     *this = LongNumber(static_cast<long long>(value));
 }
 LongNumber::LongNumber(unsigned long value){
+    pimpl = new impl;
     *this = LongNumber(static_cast<long long>(value));
 }
 LongNumber::LongNumber(unsigned long long  value){
+    pimpl = new impl;
     *this = LongNumber(static_cast<long long>(value));
 }
 LongNumber::LongNumber(short value){
+    pimpl = new impl;
     *this = LongNumber(static_cast<long long>(value));
 }
 LongNumber::LongNumber(int value){
+    pimpl = new impl;
     *this = LongNumber(static_cast<long long>(value));
 }
 LongNumber::LongNumber(long value){
+    pimpl = new impl;
     *this = LongNumber(static_cast<long long>(value));
 }
 LongNumber::LongNumber(long long value){
+    pimpl = new impl;
     if (value < 0){
         *this = LongNumber(10, false);
         value *= -1;
@@ -116,30 +112,64 @@ LongNumber::LongNumber(long long value){
     }
 }
 bool LongNumber::impl::controllo_input(char c, int base, int pos){
+#if DEBUG
+    std::cout<<"c: "<<c<<", base: "<<base<<", pos: "<<pos;
+#endif
     if (pos == 0){
-        if (c == '-' || c == '+') return true;
+        if (c == '-' || c == '+') {
+#if DEBUG
+            std::cout<<" true"<<std::endl;
+#endif
+            return true;
+        }
     }
     if (
         (c-'0'>= 0 && c-'0'<base) ||
-        (c-'A'>=10 && c-'A'<base) ||
-        (c-'a'>=10 && c-'a'<base)
-    )
+        (c-'A'>= 0 && c-'A'<base-10) ||
+        (c-'a'>= 0 && c-'a'<base-10)
+    ){
+#if DEBUG
+        std::cout<<" true"<<std::endl;
+#endif
         return true;
+    }
+#if DEBUG
+    std::cout<<" true"<<std::endl;
+#endif
     return false;
 }
-LongNumber::LongNumber(char* str, int base = 10){
+LongNumber::LongNumber(const char str[], int base){
+    pimpl = new impl;
+    pimpl->base = base;
     std::string s;
-    while (str!='\0') s += *str++;
+    while (*str!='\0') s += *str++;
     *this = LongNumber(s, base);
 }
-LongNumber::LongNumber(std::string str, int base = 10){
+LongNumber::LongNumber(const char str[]){
+    pimpl = new impl;
+    pimpl->base = 10;
+    std::string s;
+    while (*str!='\0') s += *str++;
+    *this = LongNumber(s, 10);
+}
+LongNumber::LongNumber(std::string& str){
+    pimpl = new impl;
+    *this = LongNumber(str, 10);
+}
+LongNumber::LongNumber(std::string& str, int base){
     if (base<2 || base>16) throw LongNumberException{"base must be beetween 2 and 16"};
+    pimpl = new impl;
+    pimpl->base = base;
+    pimpl->sign = true;
 
-    if (str.length() == 0) 
-        *this = LongNumber();
     for(size_t i = 0; i<str.length(); i++){
-        if (!impl::controllo_input(str[i], base, i)) throw LongNumberException{"str contains unexpected characters"};
-        if (i == 0 && str[i]== '-') 
+        if (!impl::controllo_input(str[i], base, i)) {
+#if DEBUG
+            std::cout<<"i: "<<i<<" str[i]: "<<str[i]<<std::endl;
+#endif
+            throw LongNumberException{"str contains unexpected characters"};
+        }
+        if (i == 0 && str[i] == '-') 
             pimpl->sign = false;
         else if (i == 0 && str[i] == '+') 
             pimpl->sign = true;

--- a/src/Implementation/LongNumber_GetterSetter.cpp
+++ b/src/Implementation/LongNumber_GetterSetter.cpp
@@ -33,9 +33,9 @@ LongNumber LongNumber::changeBase(int newBase) const{
             else {
                 value = (int)(c-'0')+10;
             }
-            LongNumber base_exp; //= wrapped_base^(i++);
-            LongNumber temp; //=base_exp*value;
-            //result_inBase10 += temp;
+            LongNumber base_exp = wrapped_base^(i++);
+            LongNumber temp = base_exp*value;
+            result_inBase10 += temp;
         }
     }
 
@@ -47,8 +47,8 @@ LongNumber LongNumber::changeBase(int newBase) const{
     int r = 0;
     LongNumber result;
     while(result_inBase10 != 0){
-        //r = result_inBase10 % newBase;
-        //result_inBase10 /= newBase;
+        r = result_inBase10 % newBase;
+        result_inBase10 /= newBase;
         char v = (r >= 10 && r <= 15) ? static_cast<char>('A' + (r - 10)) : static_cast<char>('0' + r);
         result.pimpl->push_back(v);
     } 

--- a/src/Implementation/LongNumber_GetterSetter.cpp
+++ b/src/Implementation/LongNumber_GetterSetter.cpp
@@ -33,9 +33,9 @@ LongNumber LongNumber::changeBase(int newBase) const{
             else {
                 value = (int)(c-'0')+10;
             }
-            LongNumber base_exp = wrapped_base^(i++);
-            LongNumber temp = base_exp*value;
-            result_inBase10 += temp;
+            LongNumber base_exp; //= wrapped_base^(i++);
+            LongNumber temp; //=base_exp*value;
+            //result_inBase10 += temp;
         }
     }
 
@@ -47,8 +47,8 @@ LongNumber LongNumber::changeBase(int newBase) const{
     int r = 0;
     LongNumber result;
     while(result_inBase10 != 0){
-        r = result_inBase10 % newBase;
-        result_inBase10 /= newBase;
+        //r = result_inBase10 % newBase;
+        //result_inBase10 /= newBase;
         char v = (r >= 10 && r <= 15) ? static_cast<char>('A' + (r - 10)) : static_cast<char>('0' + r);
         result.pimpl->push_back(v);
     } 

--- a/src/Implementation/LongNumber_ostream.cpp
+++ b/src/Implementation/LongNumber_ostream.cpp
@@ -1,0 +1,18 @@
+#include "../LongNumber_StructImpl.hpp"
+
+std::string LongNumber::getNumber() const{
+    typename impl::pcella aux = pimpl->end;
+    std::string s;
+    if (pimpl->base != 10) s += std::string("base") + std::to_string(pimpl->base) + ": ";
+    if (!pimpl->sign) s += '-';
+    if (!aux) s += '0';
+    while(aux){
+        s += aux->value;
+        aux = aux->prev;
+    }
+    return s;
+}
+
+std::ostream& operator<<(std::ostream &os, LongNumber const &number){
+    return os<<number.getNumber();
+}

--- a/src/LongNumber.hpp
+++ b/src/LongNumber.hpp
@@ -1,6 +1,8 @@
 #include <string>
 #pragma once
 
+#define DEBUG 0
+
 /**
  * @brief Class representing large numbers (bigger than 64bits) with arbitrary bases. 
  * @author Giuliano Assaggio <www.github.com/giulianoassaggio>
@@ -70,13 +72,15 @@ class LongNumber {
          * @param str The string representing the number. If void, Number == 0
          * @param base The base of the number system (default is 10).
          */
-        LongNumber(std::string str, int base = 10);
+        LongNumber(std::string &str);
+        LongNumber(std::string &str, int base);
         /**
          * @brief Constructor from string with specified base.
          * @param str The string representing the number. it MUST end with terminator \0. If void, Number == 0
          * @param base The base of the number system (default is 10).
          */
-        LongNumber(char* str, int base = 10);
+        LongNumber(const char str[]);
+        LongNumber(const char str[], int base);
 
         /**
          * @brief Addition operator.
@@ -404,6 +408,8 @@ class LongNumber {
         */
         LongNumber changeSign() const;
 
+        std::string getNumber() const;
+        
     private:
         struct impl;
         impl* pimpl;
@@ -417,17 +423,17 @@ struct LongNumberException {
 };
 
 /**
- * @brief Output stream operator for LongNumber.
- * @param os The output stream.
- * @param number The LongNumber to output.
- * @return Reference to the output stream.
- */
+* @brief Output stream operator for LongNumber.
+* @param os The output stream.
+* @param number The LongNumber to output.
+* @return Reference to the output stream.
+*/
 std::ostream& operator<<(std::ostream &os, LongNumber const &number);
 
 /**
- * @brief Input stream operator for LongNumber.
- * @param is The input stream.
- * @param number The LongNumber to input.
- * @return Reference to the input stream.
- */
+* @brief Input stream operator for LongNumber.
+* @param is The input stream.
+* @param number The LongNumber to input.
+* @return Reference to the input stream.
+*/
 std::istream& operator>>(std::istream &is, LongNumber const & Number);

--- a/src/LongNumber_StructImpl.hpp
+++ b/src/LongNumber_StructImpl.hpp
@@ -1,4 +1,5 @@
 #include "LongNumber.hpp"
+#include <iostream>
 #pragma once
 
 // private pimpl implementation
@@ -33,7 +34,7 @@ struct LongNumber::impl {
         }
         else {
             pcella aux = new cella{x, nullptr, start};
-            start = start->next = aux;
+            start = start->prev = aux;
         }
     }
     void pop_front(){
@@ -64,8 +65,14 @@ struct LongNumber::impl {
             }
         }
     }
+    impl(){
+        start = end = nullptr;
+        sign = true;
+        base = 10;
+    }
     ~impl(){
         while(start) pop_front();
+        start = end = nullptr;
     }
 
     enum comparison_result{THIS_GREATER_OTHER, THIS_LESS_OTHER, THIS_EQUALS_OTHER};

--- a/tests/Constructors.cpp
+++ b/tests/Constructors.cpp
@@ -1,0 +1,252 @@
+#include "../src/LongNumber.hpp"
+#include <iostream>
+
+int main() {
+    /*
+        CONSTRUCTORS
+    */
+
+    // default
+    std::cout<<"Default constructor with base: "<<std::endl;
+    LongNumber num1;
+    
+    
+    // default with base and sign specified
+    for (int i=2; i<17; i++){
+        try{
+            std::cout<<"Default constructor with base: "<<i<<" and sign: "<<std::boolalpha<<false<<std::endl;
+            LongNumber(i, false);
+            std::cout<<"Default constructor with base: "<<i<<" and sign: "<<std::boolalpha<<true<<std::endl;
+            LongNumber(i, true);
+        }
+        catch (LongNumberException e){
+            std::cout<<e.msg<<std::endl;
+            continue;
+        }
+    }
+ 
+    {
+        // primitive constructors
+        std::cout<<"primitive constructor, signed, positive, short"<<std::endl;
+        LongNumber((short) 1); 
+        std::cout<<"primitive constructor, signed, positive, int"<<std::endl;
+        LongNumber((int) 1);
+        std::cout<<"primitive constructor, signed, positive, long"<<std::endl;
+        LongNumber((long) 1);
+        std::cout<<"primitive constructor, signed, positive, long long"<<std::endl;
+        LongNumber((long long) 1);
+        std::cout<<"primitive constructor, signed, negative, short"<<std::endl;
+        LongNumber((short) -1);
+        std::cout<<"primitive constructor, signed, negative, int"<<std::endl;
+        LongNumber((int) -1);
+        std::cout<<"primitive constructor, signed, negative, long"<<std::endl;
+        LongNumber((long) -1);
+        std::cout<<"primitive constructor, signed, negative, long long"<<std::endl;
+        LongNumber((long long) -1);
+        std::cout<<"primitive constructor, unsigned, short"<<std::endl;
+        LongNumber((unsigned short) 1);
+        std::cout<<"primitive constructor, unsigned, int"<<std::endl;
+        LongNumber((unsigned int) 1);
+        std::cout<<"primitive constructor, unsigned, long"<<std::endl;
+        LongNumber((unsigned long) 1);
+        std::cout<<"primitive constructor, unsigned, long long"<<std::endl;
+        LongNumber((unsigned long long) 1);
+    }
+
+    // copy
+    LongNumber num2;
+    std::cout<<"Copy constructor"<<std::endl;
+    LongNumber num3{num1};
+    
+    std::cout<<"Copy self-assignment"<<std::endl;
+    num2 = num2;
+
+    std::cout<<"Copy assignment"<<std::endl;
+    num2 = num3;
+
+    //move
+    std::cout<<"move constructor"<<std::endl;
+    LongNumber num0;
+    LongNumber num4 = std::move(num0);
+
+    LongNumber num00(1);
+    std::cout<<"move constructor"<<std::endl;
+    num4 = std::move(num00);  
+
+
+    {   
+        // string constructors
+        for (int base=2; base<16; base++){
+            std::cout<<"std::string void constructor with base: "<<base<<std::endl;
+            std::string s("");
+            LongNumber x(s, base);
+        }
+    }
+  
+    {   
+        std::cout<<"std::string void constructor with base: "<<10<<std::endl;
+        std::string s0("");
+        LongNumber x0(s0); 
+        std::cout<<x0<<std::endl;    
+
+        std::cout<<"number 1"<<std::endl;
+        std::string s1("1");
+        LongNumber x1(s1);
+        std::cout<<x1<<std::endl;
+        
+        std::cout<<"number 6"<<std::endl;
+        std::string s6("6");
+        LongNumber x6(s6);
+        std::cout<<x6<<std::endl;
+
+        std::cout<<"number 10"<<std::endl;
+        std::string s10("10");
+        LongNumber x10(s10);
+        std::cout<<x10<<std::endl;
+#if DEBUG
+        try{
+            std::cout<<"number A"<<std::endl;
+            std::string s = "A";
+            LongNumber A(s);
+        } catch (LongNumberException e) {
+            std::cout<<e.msg<<std::endl;
+        }
+#endif
+        std::cout<<"std::string with negative numbers"<<std::endl;
+        std::cout<<"std::number -1, base 2"<<std::endl;
+        std::string s = "-1";
+        LongNumber A(s, 2);
+        std::cout<<A<<std::endl;
+        std::cout<<"std::number -1, base 16"<<std::endl;
+        std::string ss1 = "-1";
+        LongNumber A1(ss1, 16);
+        std::cout<<A1<<std::endl;
+        try {
+            std::cout<<"std::number -1A2F, base 16"<<std::endl;
+            std::string s2 = "-1A2F";
+            LongNumber A2(s2, 16);
+            std::cout<<A2<<std::endl;
+        }
+        catch (LongNumberException e){
+            std::cout<<e.msg<<std::endl;
+        }
+        std::cout<<"std::number -A2F, base 16"<<std::endl;
+        std::string s3 = "-A2F";
+        LongNumber A3(s3, 16);
+        std::cout<<A3<<std::endl;
+        std::cout<<"std::string with explicitly positive numbers"<<std::endl;
+        std::cout<<"std::number +1, base 2"<<std::endl;
+        std::string s4 = "+1";
+        LongNumber A4(s4, 2);
+        std::cout<<A4<<std::endl;
+        std::cout<<"std::number +1, base 16"<<std::endl;
+        std::string s5 = "+1";
+        LongNumber A5(s5, 16);
+        std::cout<<A5<<std::endl;
+        std::cout<<"std::number +1A2F, base 16"<<std::endl;
+        std::string ss6 = "+1A2F";
+        LongNumber A6(ss6, 16);
+        std::cout<<A6<<std::endl;
+        std::cout<<"std::number +A2F, base 16"<<std::endl;
+        std::string s7 = "+A2F";
+        LongNumber A7(s7, 16);
+        std::cout<<A7<<std::endl;
+
+#if DEBUG
+        for (int i=0; i<5; i++){
+            try{
+                std::cout<<"String with errors in parsing"<<std::endl;
+                if (i==0) {
+                    std::string s("-1.Z2");
+                    LongNumber(s, 16);
+                }
+                if (i==1) {
+                    std::string s("+Z-2");
+                    LongNumber(s, 16);
+                }
+                if (i==2) {
+                    std::string s("1-2");
+                    LongNumber(s, 16);
+                }
+                if (i==3) {
+                    std::string s("-.-1AA+1--2");
+                    LongNumber(s, 16);
+                }
+                if (i==4) {
+                    std::string s("A+BF");
+                    LongNumber(s, 16);
+                }
+            } catch (LongNumberException e) {
+                std::cout<<e.msg<<std::endl;
+                continue;
+            }
+        }
+#endif
+    }
+    {   
+        // string constructors
+        for (int base=2; base<17; base++){
+            std::cout<<"char* void constructor with base: "<<base<<std::endl;
+            std::cout<<LongNumber("", base)<<std::endl;
+        }
+    }
+    {   
+        std::cout<<"char* void constructor with base: "<<10<<std::endl;
+        std::cout<<LongNumber("")<<std::endl;
+        std::cout<<"number 1"<<std::endl;
+        std::cout<<LongNumber("1")<<std::endl;
+        std::cout<<"number 6"<<std::endl;
+        std::cout<<LongNumber("6")<<std::endl;
+        std::cout<<"number 10"<<std::endl;
+        std::cout<<LongNumber("10")<<std::endl;
+#if DEBUG
+        try{
+            std::cout<<"number A"<<std::endl;
+            LongNumber("A");
+        } catch (LongNumberException e) {
+            std::cout<<e.msg<<std::endl;
+        }
+#endif
+    }
+    std::cout<<"char* with negative numbers"<<std::endl;
+    std::cout<<"std::number -1, base 2"<<std::endl;
+    LongNumber A0("-1", 2);
+    std::cout<<A0<<std::endl;
+    std::cout<<"std::number -1, base 16"<<std::endl;
+    LongNumber A1("-1", 16);
+    std::cout<<A1<<std::endl;
+    std::cout<<"std::number -1A2f, base 16"<<std::endl;
+    LongNumber A2("-1A2f", 16);
+    std::cout<<A2<<std::endl;
+    std::cout<<"std::number -A2F, base 16"<<std::endl;
+    LongNumber A3("-A2F", 16);
+    std::cout<<A3<<std::endl;
+    std::cout<<"char* with explicitly positive numbers"<<std::endl;
+    std::cout<<"std::number +1, base 2"<<std::endl;
+    LongNumber A4("+1", 2);
+    std::cout<<A4<<std::endl;
+    std::cout<<"std::number +1, base 16"<<std::endl;
+    LongNumber A5("+1", 16);
+    std::cout<<A5<<std::endl;
+    std::cout<<"std::number +1a2f, base 16"<<std::endl;
+    LongNumber A6("+1a2f", 16);
+    std::cout<<A6<<std::endl;
+    std::cout<<"std::number +A2F, base 16"<<std::endl;
+    LongNumber A7("+A2F", 16);
+    std::cout<<A7<<std::endl;
+#if DEBUG
+    for (int i=0; i<5; i++){
+        try{
+            std::cout<<"String with errors in parsing"<<std::endl;
+            if (i==0) std::cout<<LongNumber("-1.,2", 16)<<std::endl;
+            if (i==1) std::cout<<LongNumber("+1-2", 16)<<std::endl;
+            if (i==2) std::cout<<LongNumber("1-2", 16)<<std::endl;
+            if (i==3) std::cout<<LongNumber("--1AA+1--2", 16)<<std::endl;
+            if (i==4) std::cout<<LongNumber("A+BF", 16)<<std::endl;
+        } catch (LongNumberException e) {
+            std::cout<<e.msg<<std::endl;
+            continue;
+        }
+    }
+#endif
+}

--- a/tests/Valgrind_constructors.log
+++ b/tests/Valgrind_constructors.log
@@ -1,0 +1,267 @@
+==502442== Memcheck, a memory error detector
+==502442== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
+==502442== Using Valgrind-3.19.0-8d3c8034b8-20220411 and LibVEX; rerun with -h for copyright info
+==502442== Command: ./a.out
+==502442== 
+--502442-- Valgrind options:
+--502442--    -v
+--502442--    --leak-check=full
+--502442-- Contents of /proc/version:
+--502442--   Linux version 6.1.0-17-amd64 (debian-kernel@lists.debian.org) (gcc-12 (Debian 12.2.0-14) 12.2.0, GNU ld (GNU Binutils for Debian) 2.40) #1 SMP PREEMPT_DYNAMIC Debian 6.1.69-1 (2023-12-30)
+--502442-- 
+--502442-- Arch and hwcaps: AMD64, LittleEndian, amd64-cx16-lzcnt-rdtscp-sse3-ssse3-avx-avx2-bmi-f16c
+--502442-- Page sizes: currently 4096, max supported 4096
+--502442-- Valgrind library directory: /usr/libexec/valgrind
+--502442-- Reading syms from /home/dade/LongNumber/tests/a.out
+--502442-- Reading syms from /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
+--502442--   Considering /usr/lib/debug/.build-id/9e/8cea20c5d657bc8721389f628f97ff617e2049.debug ..
+--502442--   .. build-id is valid
+--502442-- Reading syms from /usr/libexec/valgrind/memcheck-amd64-linux
+--502442--   Considering /usr/lib/debug/.build-id/82/26c2aa6b808ebd5a6fafb694a7fb3287f33590.debug ..
+--502442--   .. build-id is valid
+--502442--    object doesn't have a dynamic symbol table
+--502442-- Scheduler: using generic scheduler lock implementation.
+--502442-- Reading suppressions file: /usr/libexec/valgrind/default.supp
+==502442== embedded gdbserver: reading from /tmp/vgdb-pipe-from-vgdb-to-502442-by-dade-on-???
+==502442== embedded gdbserver: writing to   /tmp/vgdb-pipe-to-vgdb-from-502442-by-dade-on-???
+==502442== embedded gdbserver: shared mem   /tmp/vgdb-pipe-shared-mem-vgdb-502442-by-dade-on-???
+==502442== 
+==502442== TO CONTROL THIS PROCESS USING vgdb (which you probably
+==502442== don't want to do, unless you know exactly what you're doing,
+==502442== or are doing some strange experiment):
+==502442==   /usr/bin/vgdb --pid=502442 ...command...
+==502442== 
+==502442== TO DEBUG THIS PROCESS USING GDB: start GDB like this
+==502442==   /path/to/gdb ./a.out
+==502442== and then give GDB the following command
+==502442==   target remote | /usr/bin/vgdb --pid=502442
+==502442== --pid is optional if only one valgrind process is running
+==502442== 
+--502442-- REDIR: 0x40236e0 (ld-linux-x86-64.so.2:strlen) redirected to 0x580bb0e2 (vgPlain_amd64_linux_REDIR_FOR_strlen)
+--502442-- REDIR: 0x4021ec0 (ld-linux-x86-64.so.2:index) redirected to 0x580bb0fc (vgPlain_amd64_linux_REDIR_FOR_index)
+--502442-- Reading syms from /usr/libexec/valgrind/vgpreload_core-amd64-linux.so
+--502442--   Considering /usr/lib/debug/.build-id/ad/f1388be4d8781737b0c83fe111a5a9c6e930aa.debug ..
+--502442--   .. build-id is valid
+--502442-- Reading syms from /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so
+--502442--   Considering /usr/lib/debug/.build-id/d8/ec66cffcb23a75c3f15940674d6028709121f8.debug ..
+--502442--   .. build-id is valid
+==502442== WARNING: new redirection conflicts with existing -- ignoring it
+--502442--     old: 0x040236e0 (strlen              ) R-> (0000.0) 0x580bb0e2 vgPlain_amd64_linux_REDIR_FOR_strlen
+--502442--     new: 0x040236e0 (strlen              ) R-> (2007.0) 0x048468a0 strlen
+--502442-- REDIR: 0x40220e0 (ld-linux-x86-64.so.2:strcmp) redirected to 0x4847780 (strcmp)
+--502442-- REDIR: 0x4021350 (ld-linux-x86-64.so.2:mempcpy) redirected to 0x484b1a0 (mempcpy)
+--502442-- Reading syms from /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30
+--502442--    object doesn't have a symbol table
+--502442-- Reading syms from /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
+--502442--    object doesn't have a symbol table
+--502442-- Reading syms from /usr/lib/x86_64-linux-gnu/libc.so.6
+--502442--   Considering /usr/lib/debug/.build-id/51/657f818beb1ae70372216a99b7412b8a100a20.debug ..
+--502442--   .. build-id is valid
+==502442== WARNING: new redirection conflicts with existing -- ignoring it
+--502442--     old: 0x04b3f450 (memalign            ) R-> (1011.0) 0x04845bc0 memalign
+--502442--     new: 0x04b3f450 (memalign            ) R-> (1017.0) 0x04845b90 aligned_alloc
+==502442== WARNING: new redirection conflicts with existing -- ignoring it
+--502442--     old: 0x04b3f450 (memalign            ) R-> (1011.0) 0x04845bc0 memalign
+--502442--     new: 0x04b3f450 (memalign            ) R-> (1017.0) 0x04845b60 aligned_alloc
+--502442-- Reading syms from /usr/lib/x86_64-linux-gnu/libm.so.6
+--502442--   Considering /usr/lib/debug/.build-id/ea/87e1b3daf095cd53f1f99ab34a88827eccce80.debug ..
+--502442--   .. build-id is valid
+--502442-- REDIR: 0x4b453a0 (libc.so.6:strnlen) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b45430 (libc.so.6:strpbrk) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b43550 (libc.so.6:strcmp) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b58320 (libc.so.6:wcsnlen) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b42690 (libc.so.6:memset) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b56c60 (libc.so.6:wcslen) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b41cc0 (libc.so.6:memcpy@@GLIBC_2.14) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b56a90 (libc.so.6:wcschr) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b43440 (libc.so.6:index) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b45460 (libc.so.6:rindex) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b56b20 (libc.so.6:wcscmp) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b428d0 (libc.so.6:stpncpy) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b57070 (libc.so.6:wmemchr) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b45250 (libc.so.6:strncmp) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b42940 (libc.so.6:strcasecmp) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b447b0 (libc.so.6:strcspn) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b56bb0 (libc.so.6:wcscpy) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b433c0 (libc.so.6:strcat) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b45140 (libc.so.6:strncasecmp_l) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b41bd0 (libc.so.6:bcmp) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b42600 (libc.so.6:memrchr) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b434c0 (libc.so.6:strchrnul) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b44730 (libc.so.6:strcpy) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b429e0 (libc.so.6:strcasecmp_l) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b45010 (libc.so.6:strlen) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b452f0 (libc.so.6:strncpy) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b42850 (libc.so.6:stpcpy) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b423e0 (libc.so.6:memmove) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+==502442== Preferring higher priority redirection:
+--502442--     old: 0x04bf85c0 (__memcpy_avx_unalign) R-> (2018.0) 0x04848a60 __memcpy_avx_unaligned_erms
+--502442--     new: 0x04bf85c0 (__memcpy_avx_unalign) R-> (2018.1) 0x0484a2b0 memmove
+--502442-- REDIR: 0x4b41b50 (libc.so.6:memchr) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b45620 (libc.so.6:strspn) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b424f0 (libc.so.6:mempcpy) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b450a0 (libc.so.6:strncasecmp) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4b42790 (libc.so.6:rawmemchr) redirected to 0x48371b0 (_vgnU_ifunc_wrapper)
+--502442-- REDIR: 0x4bfe690 (libc.so.6:__strrchr_avx2) redirected to 0x48462e0 (rindex)
+--502442-- REDIR: 0x4b3e770 (libc.so.6:malloc) redirected to 0x4840740 (malloc)
+--502442-- REDIR: 0x4bfbd40 (libc.so.6:__strlen_avx2) redirected to 0x4846780 (strlen)
+--502442-- REDIR: 0x4bf7e60 (libc.so.6:__memcmp_avx2_movbe) redirected to 0x4849aa0 (bcmp)
+--502442-- REDIR: 0x4bfb450 (libc.so.6:__strcmp_avx2) redirected to 0x4847680 (strcmp)
+--502442-- REDIR: 0x4bf8570 (libc.so.6:__mempcpy_avx_unaligned_erms) redirected to 0x484adb0 (mempcpy)
+Default constructor with base: 
+--502442-- REDIR: 0x4915570 (libstdc++.so.6:operator new(unsigned long)) redirected to 0x4840ec0 (operator new(unsigned long))
+Default constructor with base: 2 and sign: false
+--502442-- REDIR: 0x49138e0 (libstdc++.so.6:operator delete(void*, unsigned long)) redirected to 0x4843930 (operator delete(void*, unsigned long))
+Default constructor with base: 2 and sign: true
+Default constructor with base: 3 and sign: false
+Default constructor with base: 3 and sign: true
+Default constructor with base: 4 and sign: false
+Default constructor with base: 4 and sign: true
+Default constructor with base: 5 and sign: false
+Default constructor with base: 5 and sign: true
+Default constructor with base: 6 and sign: false
+Default constructor with base: 6 and sign: true
+Default constructor with base: 7 and sign: false
+Default constructor with base: 7 and sign: true
+Default constructor with base: 8 and sign: false
+Default constructor with base: 8 and sign: true
+Default constructor with base: 9 and sign: false
+Default constructor with base: 9 and sign: true
+Default constructor with base: 10 and sign: false
+Default constructor with base: 10 and sign: true
+Default constructor with base: 11 and sign: false
+Default constructor with base: 11 and sign: true
+Default constructor with base: 12 and sign: false
+Default constructor with base: 12 and sign: true
+Default constructor with base: 13 and sign: false
+Default constructor with base: 13 and sign: true
+Default constructor with base: 14 and sign: false
+Default constructor with base: 14 and sign: true
+Default constructor with base: 15 and sign: false
+Default constructor with base: 15 and sign: true
+Default constructor with base: 16 and sign: false
+Default constructor with base: 16 and sign: true
+primitive constructor, signed, positive, short
+primitive constructor, signed, positive, int
+primitive constructor, signed, positive, long
+primitive constructor, signed, positive, long long
+primitive constructor, signed, negative, short
+primitive constructor, signed, negative, int
+primitive constructor, signed, negative, long
+primitive constructor, signed, negative, long long
+primitive constructor, unsigned, short
+primitive constructor, unsigned, int
+primitive constructor, unsigned, long
+primitive constructor, unsigned, long long
+Copy constructor
+Copy self-assignment
+Copy assignment
+move constructor
+move constructor
+std::string void constructor with base: 2
+std::string void constructor with base: 3
+std::string void constructor with base: 4
+std::string void constructor with base: 5
+std::string void constructor with base: 6
+std::string void constructor with base: 7
+std::string void constructor with base: 8
+std::string void constructor with base: 9
+std::string void constructor with base: 10
+std::string void constructor with base: 11
+std::string void constructor with base: 12
+std::string void constructor with base: 13
+std::string void constructor with base: 14
+std::string void constructor with base: 15
+std::string void constructor with base: 10
+0
+number 1
+1
+number 6
+6
+number 10
+--502442-- REDIR: 0x4bf85c0 (libc.so.6:__memcpy_avx_unaligned_erms) redirected to 0x484a2b0 (memmove)
+10
+std::string with negative numbers
+std::number -1, base 2
+base2: -1
+std::number -1, base 16
+--502442-- REDIR: 0x4bf8fc0 (libc.so.6:__memset_avx2_unaligned_erms) redirected to 0x484a1c0 (memset)
+base16: -1
+std::number -1A2F, base 16
+base16: -1A2F
+std::number -A2F, base 16
+base16: -A2F
+std::string with explicitly positive numbers
+std::number +1, base 2
+base2: 1
+std::number +1, base 16
+base16: 1
+std::number +1A2F, base 16
+base16: 1A2F
+std::number +A2F, base 16
+base16: A2F
+char* void constructor with base: 2
+base2: 0
+char* void constructor with base: 3
+base3: 0
+char* void constructor with base: 4
+base4: 0
+char* void constructor with base: 5
+base5: 0
+char* void constructor with base: 6
+base6: 0
+char* void constructor with base: 7
+base7: 0
+char* void constructor with base: 8
+base8: 0
+char* void constructor with base: 9
+base9: 0
+char* void constructor with base: 10
+0
+char* void constructor with base: 11
+base11: 0
+char* void constructor with base: 12
+base12: 0
+char* void constructor with base: 13
+base13: 0
+char* void constructor with base: 14
+base14: 0
+char* void constructor with base: 15
+base15: 0
+char* void constructor with base: 16
+base16: 0
+char* void constructor with base: 10
+0
+number 1
+1
+number 6
+6
+number 10
+10
+char* with negative numbers
+std::number -1, base 2
+base2: -1
+std::number -1, base 16
+base16: -1
+std::number -1A2f, base 16
+base16: -1A2F
+std::number -A2F, base 16
+base16: -A2F
+char* with explicitly positive numbers
+std::number +1, base 2
+base2: 1
+std::number +1, base 16
+base16: 1
+std::number +1a2f, base 16
+base16: 1A2F
+std::number +A2F, base 16
+base16: A2F
+--502442-- REDIR: 0x4b3ed30 (libc.so.6:free) redirected to 0x4843110 (free)
+==502442== 
+==502442== HEAP SUMMARY:
+==502442==     in use at exit: 0 bytes in 0 blocks
+==502442==   total heap usage: 215 allocs, 215 frees, 81,912 bytes allocated
+==502442== 
+==502442== All heap blocks were freed -- no leaks are possible
+==502442== 
+==502442== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)


### PR DESCRIPTION
I addressed several issues concerning constructors. Some conditional statements were utilizing uninitialized values, and there were errors and memory leaks related to move and copy semantics. I implemented an output function (`getNumber()`) along with its corresponding `operator<<`. Please review the chosen method for printing the base of the number.
I created a simple testing `main` program that encompasses various constructor scenarios.
I executed the command `g++ -g Constructors.cpp ../src/Implementation/*.cpp -o a.out && valgrind -v --leak-check=full ./a.out > Valgrind_constructors.log 2>&1 && rm ./a.out`, the output is stored in the file `Valgrind_constructors.log` within the `tests` folder.  The log indicates no memory leaks or errors. Therefore, you can proceed with further development of your library, knowing that the constructors are robust and dependable for conducting tests